### PR TITLE
Match parens and brackets as well.

### DIFF
--- a/lib/textProcessor.js
+++ b/lib/textProcessor.js
@@ -7,18 +7,18 @@ export default class textProcessor {
     this.myEditor = editor;
   //  this.cleanUp();
     var count =0;
-    atom.workspace.getActiveTextEditor().scan(/{|}/g,onFind)
+    atom.workspace.getActiveTextEditor().scan(/{|}|\[|\]|\(|\)/g,onFind)
 
     function onFind(result)
     {
-     if(result.matchText == '{')
+     if('{[('.indexOf(result.matchText) > -1)
      {
         count ++;
      }
      marker = atom.workspace.getActiveTextEditor().markScreenRange(result.range,{invalidate: 'touch'});
      colorClass = 'color'+count;
      decoration = atom.workspace.getActiveTextEditor().decorateMarker(marker, {type: 'highlight', class: colorClass, stamp: 'nms', blinker: (count == 0), BNumber: count});
-     if(result.matchText == '}')
+     if('}])'.indexOf(result.matchText) > -1)
      {
         count --;
      }


### PR DESCRIPTION
I modified matching to also add color to parenthesis and brackets.  Colors do cycle, so there may be both cyan parentheses and cyan braces on the same screen.  This is fine.

This issue has been JavaScript async code ends up with deeply nested parentheses on different lines as well.
