### PR TITLE
Needs version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nms-color-bracket",
   "main": "./lib/nms-color-bracket",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Color codes pairs of matching curly brackets to help see block structure, and quickly identify missing/extra brackets",
   "keywords": [],
   "activationCommands": {


### PR DESCRIPTION
I noticed that v0.1.1 hasn't shown up inside Atom yet. I suppose it could be because you didn't bump the version number, so I've done that for you -- but if there's anything else that needs to be done for Atom to see it, could you make that happen?